### PR TITLE
Let's eat our own dog food ;)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - flake8-bugbear
           - flake8-builtins
           - flake8-docstrings
-          # - flake8-picky-parentheses
+          - flake8-picky-parentheses
           - flake8-quotes
           - pep8-naming
   - repo: local


### PR DESCRIPTION
Enabling picky parentheses to run on itself.

Originally attempted here 
 * https://github.com/robsdedude/flake8-picky-parentheses/pull/16
 
but encountered a blocking bug that needed fixing and a new release first.