### PR TITLE
Add more exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## NEXT
+***
+**⭐ New**
+* Expanded exception for redundant parentheses that help to highlight operator precedence to also include unpacking arguments (`*`, and `**`) before function arguments ([#23](https://github.com/robsdedude/flake8-picky-parentheses/pull/23)).
+* Add exception for parentheses around multi-line `for` parts in comprehensions ([#23](https://github.com/robsdedude/flake8-picky-parentheses/pull/23)).
+
+
 ## 0.2.0
 ***
 **♻ Rework of `PAR0xx` ([#22](https://github.com/robsdedude/flake8-picky-parentheses/pull/20))**

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ exceptions to this rule:
     Even if these parentheses are redundant, they help to divide parts of
     expressions and show sequence of actions.
  3. Parts of slices
- 4. Multi-line `if`s in comprehensions.
+ 4. Multi-line `if` and `for` parts in comprehensions.
  5. Multi-line keyword arguments or argument defaults.
+
 
 Exception type 1:
 ```python
@@ -171,15 +172,21 @@ foo("a",)      # BAD
 
 Exception type 2:
 ```python
-a = (1 + 2) + 3     # GOOD
-a = (1 + 2) % 3     # GOOD
-a = 1 and (2 + 3)   # GOOD
-a = (1 / 2) * 3     # GOOD
-a = not (1 + 2)     # GOOD
-a = (not 1) + 2     # GOOD
-a = (1 + 2)         # BAD
-a = 1 + (2)         # BAD
-a = ((not 1)) + 2   # BAD
+a = (1 + 2) + 3            # GOOD
+a = (1 + 2) % 3            # GOOD
+a = 1 and (2 + 3)          # GOOD
+a = (1 / 2) * 3            # GOOD
+a = not (1 + 2)            # GOOD
+a = (not 1) + 2            # GOOD
+a = 1 + (2 if a else 3)    # GOOD
+a = foo(*(a if b else c))  # GOOD
+a = foo(*(a + b))          # GOOD
+a = foo(**(a + b))         # GOOD
+a = (1 + 2)                # BAD
+a = 1 + (2)                # BAD
+a = ((not 1)) + 2          # BAD
+a = foo(*(a))              # BAD
+a = foo(**(a))             # BAD
 ```
 
 Exception type 3:
@@ -214,6 +221,18 @@ a = [
 a = (
     b for b in c
     if (b in d)
+)
+
+# GOOD
+a = (
+    b for b in (c
+                + d)
+)
+
+# BAD
+# GOOD
+a = (
+    b for b in (c + d)
 )
 ```
 


### PR DESCRIPTION
* Expanded exception for redundant parentheses that help to highlight operator precedence to also include unpacking arguments (`*`, and `**`) before function arguments.
* Add exception for parentheses around multi-line `for` parts in comprehensions.