### PR TITLE
Allow parentheses around str concatenation in lists/tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## NEXT
 ***
+**⭐ New**
+* Exempt parentheses around multi-line strings in tuples and lists ([#34](https://github.com/robsdedude/flake8-picky-parentheses/pull/34)).
 
 
 ## 0.5.0
@@ -14,7 +16,7 @@ Changelog
 ## 0.4.0
 ***
 **⭐ New**
-* Add support for Python 3.11 ([#28](https://github.com/robsdedude/flake8-picky-parentheses/pull/28))
+* Add support for Python 3.11 ([#28](https://github.com/robsdedude/flake8-picky-parentheses/pull/28)).
 
 
 ## 0.3.2

--- a/README.md
+++ b/README.md
@@ -184,14 +184,15 @@ try to remove each pair of parentheses and see if the code still compiles and
 yields the same AST (i.e., is semantically equivalent).
 If it does, a flake (lint error) is reported. However, there are two notable
 exceptions to this rule:
- 1. Parentheses for tuple literals
+ 1. Parentheses for tuple literals.
  2. A single pair or parentheses in expressions to highlight operator
     precedence.
     Even if these parentheses are redundant, they help to divide parts of
     expressions and show sequence of actions.
- 3. Parts of slices
+ 3. Parts of slices.
  4. Multi-line<sup>[1)](#footnotes)</sup> `if` and `for` parts in comprehensions.
  5. Multi-line<sup>[1)](#footnotes)</sup> keyword arguments or argument defaults.
+ 6. String concatenation over several lines in lists and tuples .
 
 
 Exception type 1:
@@ -287,6 +288,37 @@ def foo(bar=(a
 # BAD
 def foo(bar=(a is b)):
     ...
+```
+
+Exception type 6:
+
+```python
+# GOOD
+[
+    "a",
+    (
+        "b"
+        "c"
+    ),
+    "d",
+]
+
+# This helps to avoid forgetting a comma at the end of a string spanning
+# multiple lines. Compare with:
+[
+    "a",
+    "b"
+    "c"
+    "d",
+]
+# Was the comma after "b" forgotten or was the string supposed to be "bc"?
+
+# BAD
+[
+    (
+        "a" "b"
+    ),
+]
 ```
 
 ### Footnotes:


### PR DESCRIPTION
Add a new exception

```python
[
    "a",
    (
        "b"
        "c"
    ),
    "d",
]

[
    "a",
    "b"
    "c"
    "d",
]

[
    (
        "a" "b"
    ),
]
```

This aligns the plugin with what `black --preview` does.

Closes #32 