### PR TITLE
Allow redundant parens in comprehension values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog
 =========
 
 ## NEXT
-
+**⭐ New**
+* Exempt parentheses around multi-line values in comprehensions ([#43](https://github.com/robsdedude/flake8-picky-parentheses/pull/43)).
 
 ## 0.5.4
 ***

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ exceptions to this rule:
     Even if these parentheses are redundant, they help to divide parts of
     expressions and show sequence of actions.
  3. Parts of slices.
- 4. Multi-line<sup>[1)](#footnotes)</sup> `if` and `for` parts in comprehensions.
+ 4. Multi-line<sup>[1)](#footnotes)</sup> expression, `if` and `for` parts in comprehensions.
  5. Multi-line<sup>[1)](#footnotes)</sup> keyword arguments or argument defaults.
  6. String concatenation over several lines in lists and tuples .
 
@@ -269,6 +269,32 @@ a = (
 a = (
     b for b in (c + d)
 )
+
+# GOOD
+a = (
+    (
+        1
+        + b
+    )
+    for b in c
+)
+
+# BAD
+a = (
+    (1 + b) for b in c
+)
+
+# GOOD
+a = {
+    (
+        "foo%s"
+        % b
+    ): (
+        b
+        * 2
+    )
+    for b in c
+}
 ```
 
 Exception type 5:


### PR DESCRIPTION
Add an exception for redundant parentheses in comprehension value expressions (and key expressions for dict comprehensions) if they are multi-line.

Examples:
```
[
    (
        item.isoformat()
        if isinstance(item, datetime.datetime)
        else item
    )
    for item in data
]
```

```
{
    (
        k
        * SOME_LONG_KEY_MULTIPLIER_NAME_GOES_HERE
        + LONG_NAMES_CAN_BE_ANNOYINGLY_LONG_CANT_THEY
    ): (
        v[0]
        if isinstance(v, list) and len(v) == 1
        else v
    )
    for k, v in otherdict.items()
}
```

*Not* however:
```
(
    (i * 2)
    for i in range(100)
)
```

Closes: https://github.com/robsdedude/flake8-picky-parentheses/issues/42